### PR TITLE
Fixes to dramatically improve development speed.

### DIFF
--- a/lib/server/services/ComponentService.js
+++ b/lib/server/services/ComponentService.js
@@ -756,12 +756,12 @@ module.exports = function(wilsonConfig, wilsonFrameworkConfig, logger, CacheServ
           // Get nested dependencies from the service library, and construct the service paths
           var nestedDependencies = serviceLibrary[dependency].dependencies;
           var servicePaths = _.pluck(_.pick(serviceLibrary, nestedDependencies), 'path');
-          serviceScripts = serviceScripts.concat(servicePaths);
+          serviceScripts = serviceScripts.concat(_.uniq(servicePaths));
           serviceScripts.push(serviceLibrary[dependency].path);
         }
       });
     });
-    componentJson.scripts = serviceScripts.concat(componentJson.scripts);
+    componentJson.scripts = _.uniq(serviceScripts.concat(componentJson.scripts));
 
     // Get the template data for this component
     var componentTemplates = getComponentTemplates(componentName, componentPath);
@@ -794,12 +794,12 @@ module.exports = function(wilsonConfig, wilsonFrameworkConfig, logger, CacheServ
                 // Get nested dependencies from the service library, and construct the service paths
                 var nestedDependencies = serviceLibrary[dependency].dependencies;
                 var servicePaths = _.pluck(_.pick(serviceLibrary, nestedDependencies), 'path');
-                serviceScripts = serviceScripts.concat(servicePaths);
+                serviceScripts = serviceScripts.concat(_.uniq(servicePaths));
                 serviceScripts.push(serviceLibrary[dependency].path);
               }
             });
             //logger.warn('serviceScripts', serviceScripts);
-            componentJson.scripts = serviceScripts.concat(componentJson.scripts);
+            componentJson.scripts = _.uniq(serviceScripts.concat(componentJson.scripts));
           });
         } catch (err) {
           logger.warn(_.str.sprintf('Failed to find behavior scripts in component "%s"', componentName));
@@ -808,13 +808,13 @@ module.exports = function(wilsonConfig, wilsonFrameworkConfig, logger, CacheServ
       });
 
       //console.log('behaviorScripts', behaviorScripts);
-      componentJson.scripts = componentJson.scripts.concat(behaviorScripts);
+      componentJson.scripts = _.uniq(componentJson.scripts.concat(behaviorScripts));
 
       //Add behavior dependencies
       _.each(template.dependencies.guides, function (guideName) {
         guideScripts = guideScripts.concat(getGuideScripts(guideName));
       });
-      componentJson.scripts = guideScripts.concat(componentJson.scripts);
+      componentJson.scripts = _.uniq(guideScripts.concat(componentJson.scripts));
 
       //Remove the template dependencies to reduce the outputted JSON size
       delete template.dependencies;

--- a/lib/server/wilson-config.json
+++ b/lib/server/wilson-config.json
@@ -73,6 +73,7 @@
     },
     "caching": {
       "useServerCache": false,
+      "readChangeList": false,
       "folder": "server/.cache",
       "maxAge": {
         "assets":     1000,

--- a/lib/server/wilson.js
+++ b/lib/server/wilson.js
@@ -99,6 +99,14 @@ module.exports = function(app, appWilsonConfigJson, dependencies) {
     app.use(require('prerender-node'));//.set('prerenderToken', 'WILSON_PRERENDER_TOKEN'));
   }
 
+  //COMPONENT INIT
+  var ComponentService = container.get('ComponentService');
+  ComponentService.init({
+    version: wilsonConfig.client.app.version,
+    useCache: wilsonConfig.server.caching.useServerCache,
+    readChangeList: wilsonConfig.server.caching.readChangeList
+  });
+
   //ROUTING
   var router = express.Router();
 


### PR DESCRIPTION
Looks like when Wilson was separated for its own npm packaging we left out the ComponentService dependency priming on startup.  That also exposed the fact that there was no config for reading from a changeList to update itemized changes rather than rebuilding the full dependency library on each component request.

Effectively, this change puts back in the dependency priming on Wilson startup and also adds a readChangeList flag in the server.caching config for specifying when to support a changeList (defaults to false.  Override in your development config.)

One more fix provided was to fix duplicated paths in the dependency lists inside of components.json. Duplicates were causing the lists to grow substantially large and heavily bloating the weight of the file and thus the memory space required for caching during runtime.