### PR TITLE
Updating to account for new version of lodash.

### DIFF
--- a/lib/server/utils/HtLodash.js
+++ b/lib/server/utils/HtLodash.js
@@ -14,7 +14,7 @@ function mergeAll() {
     return _.isArray(a) ? _.union(a, b) : undefined;
   });
 
-  return _.merge.apply(null, argsArray);
+  return _.mergeWith.apply(null, argsArray);
 }
 
 


### PR DESCRIPTION
Apparently in the latest lodash version the "merge" method no longer takes the customizer argument.  You must use the "mergeWith" in order to provide the customizer..... Thanks lodash team!