### PR TITLE
Added support for preloading marked routes after initial route fulfillment

### DIFF
--- a/lib/client/src/services/ComponentLoaderService.js
+++ b/lib/client/src/services/ComponentLoaderService.js
@@ -97,12 +97,13 @@ wilson.service('ComponentLoaderService', ['ResourceLoaderService', '$q', '$http'
      * @param componentName
      */
     function loadComponent(componentName) {
-      var cachedData  = _componentCache[componentName];
+      var cachedComponent  = _componentCache[componentName];
 
-      // If component is not cached then fetch it 
-      if (!cachedData) {
+      // If component is not cached then fetch it and store its promise
+      if (!cachedComponent) {
+        cachedComponent = _componentCache[componentName] = {};
 
-        return fetchComponentData(componentName).then(function(compData) {
+        return (cachedComponent.promise = fetchComponentData(componentName).then(function(compData) {
           // If version matches, load resources
           if (_appVersion === compData.version) {
             return ResourceLoaderService.loadResourceBundle(compData).then(function() { return compData; }, $q.reject);
@@ -111,13 +112,16 @@ wilson.service('ComponentLoaderService', ['ResourceLoaderService', '$q', '$http'
           return compData;
         }).then(function(compData) {
           // Cache and return the component data
-          return (_componentCache[componentName] = compData);
-        }).catch(function() {
-          return $q.reject('Failed to load component [' + componentName + ']: There was a problem fetching the component from the server.');
-        });
-
+          return (cachedComponent.data = compData);
+        }).catch(function(e) {
+          _componentCache[componentName] = null;
+          return $q.reject(e);
+        }));
       }
-      
+
+      // If the component is cached, but there is no data, return the promise
+      if (!cachedComponent.data) { return cachedComponent.promise; }
+
       // If its time for an update check, get check the server version to see if we are out-of-date
       if ((Date.now() - _lastUpdate) > _updateMillis) {
         // We haven't checked the server version in a while, make sure we are up to date
@@ -125,15 +129,15 @@ wilson.service('ComponentLoaderService', ['ResourceLoaderService', '$q', '$http'
           // If the server application is a different version than we do resolve as out-of-date
           if (versionInfo.version !== _appVersion) { return $q.when({ version: 'out-of-date' }); }
 
-          // Update the last check time and return our cachedData
+          // Update the last check time and return our cachedComponent data
           _lastUpdate = Date.now();
 
-          return cachedData;
+          return cachedComponent.data;
         }, $q.reject);
       }
 
       // Otherwise, resolve the cache component data
-      return $q.when(cachedData);
+      return $q.when(cachedComponent.data);
     }
 
     // endregion

--- a/lib/client/src/wilson.js
+++ b/lib/client/src/wilson.js
@@ -560,8 +560,31 @@
         // endregion
 
 
+        //   ____           _                 _ _
+        //  |  _ \ _ __ ___| | ___   __ _  __| (_)_ __   __ _
+        //  | |_) | '__/ _ \ |/ _ \ / _` |/ _` | | '_ \ / _` |
+        //  |  __/| | |  __/ | (_) | (_| | (_| | | | | | (_| |
+        //  |_|   |_|  \___|_|\___/ \__,_|\__,_|_|_| |_|\__, |
+        //                                              |___/
+        // region preloading
+
         // Declare any pre-loaded items on this wilson instance
         _.each(_preloadQueue, function(item) { _instance[item.type].apply(_instance, item.args); });
+
+        // Preload any marked route components
+        var cleanup = $rootScope.$on('$locationChangeSuccess', function() {
+          var loaded = {};
+          _.each(_instance.config.routes, function(route) {
+            if (route.preload && !loaded[route.component]) {
+              loaded[route.component] = ComponentLoaderService.load(route.component);
+            }
+          });
+
+          cleanup();  // Remove this one-time handling operation
+        });
+
+        // endregion
+
       }
     ]);
 


### PR DESCRIPTION
Routes in routing.json can now be marked preload: true which designates that the component for that route should be silently loaded after the first $locationChangeSuccess event is fired. This allows applications to optimize for user experience when navigating.